### PR TITLE
Fix build error and update version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,45 +16,5 @@ kotlin {
 }
 
 repositories {
-  mavenLocal()
-}
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-/// hidden part
-repositories {
-  maven(url = "https://dl.bintray.com/kotlin/kotlin-eap")
-  maven(url = "https://dl.bintray.com/kotlin/kotlin-dev")
+  mavenCentral()
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,60 +1,26 @@
 plugins {
-  kotlin("js") version "1.3.50"
+  id("org.jetbrains.kotlin.js") version "1.3.61"
 }
 
 kotlin {
   target {
     useCommonJs()
     nodejs()
+    browser {
+
+    }
   }
 
-  sourceSets["main"].dependencies {
-    implementation(kotlin("stdlib-js"))
-
-    implementation(npm("left-pad", "1.3.0"))
+  sourceSets.main {
+    dependencies {
+      implementation(npm("left-pad"))
+    }
   }
 }
 
 repositories {
-  mavenLocal()
+  mavenCentral()
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-/// hidden part
-repositories {
-  maven(url = "https://dl.bintray.com/kotlin/kotlin-eap")
-  maven(url = "https://dl.bintray.com/kotlin/kotlin-dev")
+dependencies {
+  implementation(kotlin("stdlib-js"))
 }

--- a/src/main/kotlin/App.kt
+++ b/src/main/kotlin/App.kt
@@ -1,4 +1,4 @@
 fun main() {
   println("Kotlin rocks!")
-  leftPad("1.3.50", 50)
+  println(leftPad("1.3.50", 50))
 }

--- a/src/main/resources/index.html
+++ b/src/main/resources/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Hello, Kotlin/JS!</title>
+</head>
+<body>
+<canvas width="200" height="200" id="myCanvas"></canvas>
+</body>
+<script src="kotlin-js-demo-1.3.50.js"></script>
+</html>


### PR DESCRIPTION
When I run `git clone git@github.com:JetBrains/kotlin-js-demo-1.3.50.git && cd kotlin-js-demo-1.3.50 && git checkout b528efc && ./gradlew run`, the following error is thrown:

```
FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':compileKotlinJs'.
> Could not resolve all files for configuration ':kotlinCompilerClasspath'.
   > Could not find org.jetbrains.intellij.deps:trove4j:1.0.20181211.
     Searched in the following locations:
       - file:/Users/breandan/.m2/repository/org/jetbrains/intellij/deps/trove4j/1.0.20181211/trove4j-1.0.20181211.pom
       - file:/Users/breandan/.m2/repository/org/jetbrains/intellij/deps/trove4j/1.0.20181211/trove4j-1.0.20181211.jar
       - https://dl.bintray.com/kotlin/kotlin-eap/org/jetbrains/intellij/deps/trove4j/1.0.20181211/trove4j-1.0.20181211.pom
       - https://dl.bintray.com/kotlin/kotlin-eap/org/jetbrains/intellij/deps/trove4j/1.0.20181211/trove4j-1.0.20181211.jar
       - https://dl.bintray.com/kotlin/kotlin-dev/org/jetbrains/intellij/deps/trove4j/1.0.20181211/trove4j-1.0.20181211.pom
       - https://dl.bintray.com/kotlin/kotlin-dev/org/jetbrains/intellij/deps/trove4j/1.0.20181211/trove4j-1.0.20181211.jar
     Required by:
         project : > org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.50
   > Could not find org.jetbrains:annotations:13.0.
     Searched in the following locations:
       - file:/Users/breandan/.m2/repository/org/jetbrains/annotations/13.0/annotations-13.0.pom
       - file:/Users/breandan/.m2/repository/org/jetbrains/annotations/13.0/annotations-13.0.jar
       - https://dl.bintray.com/kotlin/kotlin-eap/org/jetbrains/annotations/13.0/annotations-13.0.pom
       - https://dl.bintray.com/kotlin/kotlin-eap/org/jetbrains/annotations/13.0/annotations-13.0.jar
       - https://dl.bintray.com/kotlin/kotlin-dev/org/jetbrains/annotations/13.0/annotations-13.0.pom
       - https://dl.bintray.com/kotlin/kotlin-dev/org/jetbrains/annotations/13.0/annotations-13.0.jar
     Required by:
         project : > org.jetbrains.kotlin:kotlin-compiler-embeddable:1.3.50 > org.jetbrains.kotlin:kotlin-stdlib:1.3.50

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 1s
```

This PR fixes the error.